### PR TITLE
Running server as current user

### DIFF
--- a/derpserver.service
+++ b/derpserver.service
@@ -3,8 +3,8 @@ Description=Derp Server service
 After=syslog.target
 
 [Service]
-WorkingDirectory=/opt/derpserver
-ExecStart=/bin/java -jar /opt/derpserver/derpserver.jar
+WorkingDirectory=%h/.local/derpserver/
+ExecStart=/bin/java -jar derpserver.jar
 ExecStop=/bin/kill -15 $MAINPID
 SuccessExitStatus=143
 

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 ARTIFACT_FILE="derpserver.jar"
 ARTIFACT_FOLDER="server/build/libs"
 
-INSTALLATION_FOLDER="~/.local/derpserver"
+INSTALLATION_FOLDER="$HOME/.local/derpserver"
 
 PROPERTIES_FILE="application.properties"
 SYSTEMD_FILE="derpserver.service"

--- a/install.sh
+++ b/install.sh
@@ -3,10 +3,11 @@
 ARTIFACT_FILE="derpserver.jar"
 ARTIFACT_FOLDER="server/build/libs"
 
-INSTALLATION_FOLDER="/opt/derpserver/"
+INSTALLATION_FOLDER="~/.local/derpserver"
 
 PROPERTIES_FILE="application.properties"
 SYSTEMD_FILE="derpserver.service"
+SYSTEMD_FOLDER="$HOME/.config/systemd/user"
 
 echo "Building Server Executable"
 sleep 2
@@ -17,12 +18,17 @@ mkdir -p $INSTALLATION_FOLDER
 
 touch $INSTALLATION_FOLDER/$PROPERTIES_FILE
 
-systemctl stop $SYSTEMD_FILE
+echo "Stopping server..."
+systemctl --user stop $SYSTEMD_FILE
 
+echo "Copying file $ARTIFACT_FOLDER/$ARTIFACT_FILE to $INSTALLATION_FOLDER/$ARTIFACT_FILE"
 cp $ARTIFACT_FOLDER/$ARTIFACT_FILE $INSTALLATION_FOLDER/$ARTIFACT_FILE
 
-echo "Make sure to install the systemd unit file"
-echo "cp -f $SYSTEMD_FILE /etc/systemd/system/$SYSTEMD_FILE"
+echo "Installing systemd unit $SYSTEMD_FILE in $SYSTEMD_FOLDER/$SYSTEMD_FILE"
+mkdir -p $SYSTEMD_FOLDER
+cp -f $SYSTEMD_FILE $SYSTEMD_FOLDER/$SYSTEMD_FILE
 
-systemctl daemon-reload
-systemctl restart $SYSTEMD_FILE
+echo "Starting server"
+systemctl --user daemon-reload
+systemctl --user restart $SYSTEMD_FILE
+systemctl --user enable $SYSTEMD_FILE


### PR DESCRIPTION
The previous installation script required root permissions to install and run. This change installs the systemd unit in the user's folder and runs it from there. This gets rid of the problem of authentication.